### PR TITLE
Add support for Joomla passwords

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -116,7 +116,9 @@ after_initialize do
             AlternativePassword::check_sha256(password, crypted_pass) ||
             AlternativePassword::check_wordpress(password, crypted_pass) ||
             AlternativePassword::check_wbblite(password, crypted_pass) ||
-            AlternativePassword::check_unixcrypt(password, crypted_pass)
+            AlternativePassword::check_unixcrypt(password, crypted_pass) ||
+            AlternativePassword::check_joomla_md5(password, crypted_pass) ||
+            AlternativePassword::check_joomla_3_2(password, crypted_pass)
         end
 
         def self.check_bcrypt(password, crypted_pass)
@@ -180,6 +182,20 @@ after_initialize do
 
         def self.check_unixcrypt(password, crypted_pass)
             UnixCrypt.valid?(password, crypted_pass)
+        end
+     
+        def self.check_joomla_md5(password, crypted_pass)
+            hash, salt = crypted_pass.split(':', 2)
+            !salt.nil? && hash == Digest::MD5.hexdigest(password + salt)
+        end
+
+        def self.check_joomla_3_2(password, crypted_pass)
+            crypted_pass.gsub! /^\$2y\$/, '$2a$'
+            begin
+              BCrypt::Password.new(crypted_pass) == password
+            rescue
+              false
+            end
         end
     end
  

--- a/plugin.rb
+++ b/plugin.rb
@@ -35,6 +35,7 @@ require 'digest'
     end
 
     def check(pw, hash)
+      return false unless hash.start_with?('$P$')
       crypt(pw, hash) == hash
     end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -35,7 +35,6 @@ require 'digest'
     end
 
     def check(pw, hash)
-      return false unless hash.start_with?('$P$')
       crypt(pw, hash) == hash
     end
 
@@ -204,4 +203,3 @@ after_initialize do
     end
  
 end
-


### PR DESCRIPTION
Joomla (and Kunena forum) uses 3 different methods of hashing passwords.

Original scheme is hash:salt where hash is MD5(password + salt)
Joomla 2.5 uses the same scheme as Wordpress (passwords beginning $P$)
Joomla 3.2 uses PhPass and bcrypt (passwords beginning $2y$


P.S. sorry for the multiple commits here. Still getting my head around using GitHub for multiple changes.