### PR TITLE
Fixed no conversion of nil to String in check_q2a

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -208,7 +208,9 @@ after_initialize do
 
         def self.check_q2a(password, crypted_pass)
             salt, hash = crypted_pass.split(':', 2)
-            sha1 = Digest::SHA1.hexdigest(salt[0..7] + password + salt[-8..-1])
+            salt_prefix = salt[0..7] || ""
+            salt_postfix = salt[-8..-1] || ""
+            sha1 = Digest::SHA1.hexdigest(salt_prefix + password + salt_postfix)
             hash == sha1
         end
 


### PR DESCRIPTION
I've noticed users that haven't visited by community for a while to be unable to login and even send password resets over the last couple of days. I was able to track down the cause to the newly added support for Q2A.

A string `m0OO&:dfd8942a0affeb062438be8de6ae4600` gives a salt that is shorter than 8 characters, so that `salt[-8..-1]` returns `nil` which triggers a `TypeError (no implicit conversion of nil into String)`.