### PR TITLE
fix unix-crypt require syntax

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -23,7 +23,7 @@
 
 
 gem 'bcrypt', '3.1.3'
-gem 'unix-crypt', '1.3.0', :require_name => 'unix_crypt'
+gem 'unix-crypt', '1.3.0', require: 'unix_crypt'
 
 gem 'ffi', '1.15.5', require: false
 gem 'ffi-compiler', '1.0.1', require: false


### PR DESCRIPTION
Bundle reported:

[!] There was an error parsing `Gemfile`: You passed
:require_name as an option for gem 'unix-crypt', but it is
invalid. Valid options are: group, groups, git, path, glob, name,
branch, ref, tag, require, submodules, platform, platforms, type,
source, install_if, gemfile, github, gist, bitbucket. You may be able
to resolve this by upgrading Bundler to the newest version.. Bundler
cannot continue.

Looks like maybe :require_name was ignored before, but now bundler is
validating the options passed to it.

This changes it to the correct way of naming the file to require.