### PR TITLE
Add Drupal 7 checks for migrated Drupal 6 hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/gems
+/auto_generated

--- a/plugin.rb
+++ b/plugin.rb
@@ -121,7 +121,13 @@ require "base64"
     def check(password, crypted_pass)
       return false if password.nil? or crypted_pass.nil?
 
-      crypt(password, crypted_pass[0..11]) == crypted_pass
+      # passwords migrated from drupal 6 start with a 'U' and crypt the MD5-hashed password
+      if crypted_pass[0] == 'U'
+        crypt(Digest::MD5.hexdigest(password), crypted_pass[1..12]) == crypted_pass[1..-1]
+      else
+        # normal drupal 7 passwords
+        crypt(password, crypted_pass[0..11]) == crypted_pass
+      end
     end
 
     def crypt(password, setting)

--- a/spec/drupal_spec.rb
+++ b/spec/drupal_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ::AlternativePassword do
+  PASSWORD = "password"
+  DRUPAL6_PASSWORD_HASH = "5f4dcc3b5aa765d61d8327deb882cf99"
+  DRUPAL6_TO_7_PASSWORD_HASH = "U$S$9Mgn6dLYe2Fhpoh/w/B1i53mzshiyA4BscrcKyMXNrccMeWnRK.W"
+  DRUPAL7_PASSWORD_HASH = "$S$DNX2.wYzcK0HRWPjbbA2xXbHXsOizN.WxHYcn6o.KMwRyTGLtStx"
+
+  it "passes with drupal 7 hashes" do
+    expect(::AlternativePassword.check_drupal7(PASSWORD, DRUPAL7_PASSWORD_HASH)).to be true
+  end
+
+  it "passes with drupal 7 hashes imported from Drupal 6" do
+    expect(::AlternativePassword.check_drupal7(PASSWORD, DRUPAL6_TO_7_PASSWORD_HASH)).to be true
+  end
+
+  it "passes with drupal 6 hashes" do
+    expect(::AlternativePassword.check_md5(PASSWORD, DRUPAL6_PASSWORD_HASH)).to be true
+  end
+end
+


### PR DESCRIPTION
References:

- [Preserving User Passwords](https://www.drupal.org/node/1349758)
- [D7 check](https://api.drupal.org/api/drupal/includes%21password.inc/function/user_check_password/7.x)