### PR TITLE
Add check for VB5 compatible argon2id password

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -252,9 +252,11 @@ after_initialize do
         end
 
         def self.check_argon(password, crypted_pass)
-          begin
             return false unless crypted_pass[0..9] == '$argon2id$'
-            return Argon2::Password.verify_password(password, crypted_pass)
+            # Try plain password first (standard argon2id systems)
+            return true if Argon2::Password.verify_password(password, crypted_pass)
+            # Fall back to MD5-prehashed password (vBulletin 5 MD5s client-side before hashing)
+            return Argon2::Password.verify_password(Digest::MD5.hexdigest(password), crypted_pass)
           rescue
             false
           end


### PR DESCRIPTION
VBulletin 5 takes the user's password, runs it through MD5 in the browser, then transmits that hash to the backend. This means that the token stored in the MySQL database is not the hash of the user's password. It is the hash of the MD5 of the user's password. So this adds one more test to see if the supplied password matches this approach. I did a VB5 migration to Discourse that did not work with the `import_pass` until I made this change.

If someone wants to do a vb5-to-Discourse migration and benefit from this, however, they also need to modify the [`vbulletin5.rb` import script from the discourse repo](https://github.com/discourse/discourse/blob/main/script/import_scripts/vbulletin5.rb#L84). I will be submitting a PR to them for that separately.

The `vbulletin5.rb` script has these lines (around line 84). The last line, matching argon2id, has to be added before the users are imported. Otherwise users that have an argon2id in MySQL are skipped and their old vb5 password doesn't get stored in `import_pass`.

```ruby
            CASE WHEN u.scheme='blowfish:10' THEN token
                 WHEN u.scheme='legacy' THEN REPLACE(token, ' ', ':')
                 WHEN u.scheme='argon2id:::' THEN token
```